### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ structdoc-derive = { version = "~0.1.3", path = "structdoc-derive", optional = t
 [dev-dependencies]
 serde = "~1"
 serde_derive = "~1"
-version-sync = "~0.6"
+version-sync = "~0.8"

--- a/structdoc-derive/Cargo.toml
+++ b/structdoc-derive/Cargo.toml
@@ -23,7 +23,7 @@ syn = "~0.15.26"
 unindent = "~0.1"
 
 [dev-dependencies]
-version-sync = "~0.6"
+version-sync = "~0.8"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.